### PR TITLE
Support two-timepoint classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,40 @@ cm, pred, pseudotime, prob = run_sceptic_and_evaluate(
 - ✅ More intuitive and less error-prone
 - ✅ Backward compatible with existing code
 
+### Two-Timepoint Datasets
+
+Sceptic supports classification datasets with exactly two time points for both
+`svm` and `xgboost`.
+
+Please note:
+- this setting was not benchmarked in the original Sceptic study
+- results should be interpreted with additional caution
+- pseudotime values in this setting are derived from binary class probabilities
+
+For time-series applications, datasets with three or more time points remain the
+intended use case.
+
+### IMPORTANT: Regression Mode Label Requirements
+
+When using regression mode, labels must be the actual time values, not encoded
+class IDs.
+
+Correct usage:
+
+```python
+time_labels = np.array([0, 8, 16, 0, 8, 16])
+```
+
+Incorrect usage:
+
+```python
+encoded_labels = np.array([0, 1, 2, 0, 1, 2])
+```
+
+Using encoded labels in regression mode can artificially inflate performance and
+lead to misleading pseudotime estimates. If your labels are categorical class
+IDs, use classification mode instead.
+
 Sceptic also includes utility modules for comprehensive evaluation and publication-quality visualization!
 
 ### Evaluation Utilities

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,17 @@ Advanced evaluation and visualization using the new utility modules:
 
 **Recommended for:** Users preparing results for publication or who need detailed performance metrics.
 
+### 4. Two-Timepoint Classification (`two_timepoint_classification.py`)
+Short script showing how to run Sceptic on a two-timepoint subset of the bundled
+scGEM dataset:
+- demonstrates both `svm` and `xgboost`
+- uses the existing example data rather than a synthetic toy dataset
+- documents that `kfold` is the supported CV mode for two time points
+- reminds users that this setting was not benchmarked in the original study
+
+**Recommended for:** Users with exactly two time points who want a minimal
+working example.
+
 ## Getting Started
 
 ### Installation
@@ -60,6 +71,12 @@ pip install jupyter matplotlib seaborn scipy
    jupyter notebook
    ```
 4. Open any of the example notebooks
+
+To run the two-timepoint script directly from the repository root:
+
+```bash
+python examples/two_timepoint_classification.py
+```
 
 ## Data Requirements
 

--- a/examples/two_timepoint_classification.py
+++ b/examples/two_timepoint_classification.py
@@ -1,0 +1,87 @@
+"""
+Example: run Sceptic on a two-timepoint subset of the bundled scGEM dataset.
+
+This example uses only the first two developmental time points from scGEM to
+demonstrate the supported two-class classification workflow. LOTO is not used
+here because it is not meaningful with only two time points.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from sceptic import run_sceptic_and_evaluate
+
+
+def load_two_timepoint_scgem():
+    """Load the bundled scGEM data and keep only two time points."""
+    data = np.loadtxt("example_data/scGEM/expression.txt")
+    raw_labels = np.loadtxt("example_data/scGEM/expression_type.txt")
+
+    time_lookup = {
+        0.0: 0.0,
+        1.0: 8.0,
+    }
+    keep_mask = np.isin(raw_labels, list(time_lookup))
+
+    subset_data = data[keep_mask]
+    subset_labels = np.array([time_lookup[value] for value in raw_labels[keep_mask]])
+    label_list = np.array(sorted(time_lookup.values()), dtype=float)
+    return subset_data, subset_labels, label_list
+
+
+def run_example(method, data, labels, label_list):
+    """Run Sceptic with a method-specific parameter grid."""
+    if method == "svm":
+        parameters = {
+            "C": [1, 10],
+            "kernel": ["linear", "rbf"],
+            "gamma": ["scale"],
+        }
+    else:
+        parameters = {
+            "max_depth": [3, 5],
+            "learning_rate": [0.1, 0.3],
+            "n_estimators": [100],
+            "subsample": [0.8],
+        }
+
+    cm, predicted_labels, pseudotime, probabilities = run_sceptic_and_evaluate(
+        data=data,
+        labels=labels,
+        label_list=label_list,
+        parameters=parameters,
+        method=method,
+        use_gpu=False,
+    )
+
+    print(f"\n=== {method.upper()} ===")
+    print("Confusion matrix:")
+    print(cm)
+    print("Predicted labels (first 10):", predicted_labels[:10])
+    print("Pseudotime (first 10):", pseudotime[:10])
+    print("Probabilities (first row):", probabilities[0])
+
+
+def main():
+    data, labels, label_list = load_two_timepoint_scgem()
+
+    print("Two-timepoint scGEM subset loaded")
+    print(f"Data shape: {data.shape}")
+    print(f"Time points: {label_list}")
+    print(
+        "Cells per time point:",
+        [int(np.sum(labels == time_point)) for time_point in label_list],
+    )
+    print(
+        "Note: two-timepoint classification is supported, but this setting "
+        "was not benchmarked in the original Sceptic study."
+    )
+    print("Note: use k-fold CV for two time points; LOTO is not supported.")
+
+    for method in ("svm", "xgboost"):
+        run_example(method, data, labels, label_list)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sceptic/sceptic.py
+++ b/src/sceptic/sceptic.py
@@ -32,11 +32,17 @@ def _create_xgb_classifier(num_classes, use_gpu=False):
     xgb_version = version.parse(xgb.__version__)
 
     # Base parameters that work across versions
-    base_params = {
-        'objective': 'multi:softprob',
-        'num_class': num_classes,
-        'eval_metric': 'mlogloss'
-    }
+    if num_classes == 2:
+        base_params = {
+            'objective': 'binary:logistic',
+            'eval_metric': 'logloss'
+        }
+    else:
+        base_params = {
+            'objective': 'multi:softprob',
+            'num_class': num_classes,
+            'eval_metric': 'mlogloss'
+        }
 
     # Version-specific GPU parameters
     if xgb_version >= version.parse("3.1.0"):
@@ -69,6 +75,8 @@ def _create_xgb_classifier(num_classes, use_gpu=False):
             f"Using minimal configuration.",
             UserWarning
         )
+        if num_classes == 2:
+            return xgb.XGBClassifier(objective='binary:logistic')
         return xgb.XGBClassifier(
             objective='multi:softprob',
             num_class=num_classes
@@ -119,6 +127,15 @@ def run_sceptic_and_evaluate(data, labels, label_list=None, parameters=None, met
     # Handle labels and label_list
     # Check if labels need encoding (contain non-consecutive integers or floats)
     unique_labels = np.unique(labels)
+
+    if len(unique_labels) == 2:
+        warnings.warn(
+            "Two-timepoint classification is supported, but this setting was "
+            "not benchmarked in the original Sceptic study. Interpret results "
+            "with additional caution.",
+            UserWarning,
+            stacklevel=2
+        )
 
     # If label_list is not provided, infer it from labels
     if label_list is None:
@@ -184,7 +201,11 @@ def run_sceptic_and_evaluate(data, labels, label_list=None, parameters=None, met
         clf.fit(X_train, y_train)
         predicted = clf.predict(X_test)
         label_predicted[test_index] = predicted
-        cm += sklearn.metrics.confusion_matrix(y_test, predicted)
+        cm += sklearn.metrics.confusion_matrix(
+            y_test,
+            predicted,
+            labels=np.arange(len(label_list))
+        )
 
         try:
             prob = clf.predict_proba(X_test)

--- a/test/test_two_timepoint_support.py
+++ b/test/test_two_timepoint_support.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+import sceptic.sceptic as sceptic_module
+
+
+class _DummyGridSearch:
+    def __init__(self, estimator, parameters, cv):
+        self.estimator = estimator
+
+    def fit(self, X, y):
+        return self
+
+    def predict(self, X):
+        return (X[:, 0] >= 3).astype(int)
+
+    def predict_proba(self, X):
+        predicted = self.predict(X)
+        probabilities = np.zeros((X.shape[0], 2), dtype=float)
+        probabilities[predicted == 0] = np.array([0.8, 0.2])
+        probabilities[predicted == 1] = np.array([0.3, 0.7])
+        return probabilities
+
+
+class _TwoFoldSingleClassTestKFold:
+    def __init__(self, n_splits, random_state=None, shuffle=False):
+        self.n_splits = n_splits
+
+    def split(self, data):
+        yield np.array([2, 3, 4, 5]), np.array([0, 1])
+        yield np.array([0, 1, 4, 5]), np.array([2, 3])
+        yield np.array([0, 1, 2, 3]), np.array([4, 5])
+
+
+def test_xgboost_uses_binary_objective_for_two_classes():
+    model = sceptic_module._create_xgb_classifier(num_classes=2, use_gpu=False)
+
+    assert model.get_params()["objective"] == "binary:logistic"
+
+
+def test_two_timepoint_classification_warns_and_computes_pseudotime(monkeypatch):
+    monkeypatch.setattr(sceptic_module, "GridSearchCV", _DummyGridSearch)
+    monkeypatch.setattr(sceptic_module, "KFold", _TwoFoldSingleClassTestKFold)
+
+    data = np.arange(12, dtype=float).reshape(6, 2)
+    labels = np.array([0, 0, 0, 1, 1, 1], dtype=int)
+    label_list = np.array([0.0, 10.0], dtype=float)
+
+    with pytest.warns(UserWarning, match="Two-timepoint classification is supported"):
+        cm, label_predicted, pseudotime, sceptic_prob = sceptic_module.run_sceptic_and_evaluate(
+            data=data,
+            labels=labels,
+            label_list=label_list,
+            parameters={"max_depth": [3]},
+            method="xgboost",
+            use_gpu=False,
+        )
+
+    assert cm.shape == (2, 2)
+    assert np.array_equal(label_predicted, np.array([0, 0, 1, 1, 1, 1], dtype=float))
+    assert sceptic_prob.shape == (6, 2)
+    assert np.allclose(pseudotime[:4], np.array([2.0, 2.0, 7.0, 7.0]))
+    assert np.allclose(pseudotime[4:], np.array([7.0, 7.0]))


### PR DESCRIPTION
  - adds binary XGBoost support for 2-timepoint classification
  - warns that 2-timepoint mode was not benchmarked in the original study
  - documents that this setting should use kfold rather than loto
  - adds focused tests and a runnable example using the bundled scGEM data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two-timepoint classification datasets with SVM and XGBoost models
  * Added new example script demonstrating two-timepoint classification workflow

* **Documentation**
  * Added guidance on two-timepoint dataset usage, including cautions and best practices
  * Added regression mode label requirements with usage examples and warnings for correct implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->